### PR TITLE
Choose email address as the username before choosing openid URL

### DIFF
--- a/common.php
+++ b/common.php
@@ -322,12 +322,18 @@ function openid_create_new_user($identity_url, &$user_data) {
 		$username = openid_generate_new_username($user_data['nickname'], false);
 	}
 
+	// try using email address before resorting to URL
+	if (empty($username) && array_key_exists('user_email', $user_data)) {
+		$username = openid_generate_new_username($user_data['user_email'], false);
+	}
+
 	// finally, build username from OpenID URL
 	if (empty($username)) {
 		$username = openid_generate_new_username($identity_url);
 	}
 
 	$user_data['user_login'] = $username;
+	$user_data['display_name'] = $username;
 	$user_data['user_pass'] = substr( md5( uniqid( microtime() ) ), 0, 7);
 	$user_id = wp_insert_user( $user_data );
 


### PR DESCRIPTION
Specifically, Google's URL is tremendously terrible, but the only other information they give is the email. I think in most cases the email would be preferable over the openid URL. In addition, we could do some email address munging to prevent scrapers, or change the 'displayname' property to only be the user name section of the email address (yincrash be the display name, while yincrash@gmail.com be the username).