### PR TITLE
PHP 5.4 incompatibility

### DIFF
--- a/lib/Auth/OpenID/Server.php
+++ b/lib/Auth/OpenID/Server.php
@@ -1704,7 +1704,7 @@ class Auth_OpenID_Server {
     {
         if (method_exists($this, "openid_" . $request->mode)) {
             $handler = array($this, "openid_" . $request->mode);
-            return call_user_func($handler, &$request);
+            return call_user_func($handler, $request);
         }
         return null;
     }


### PR DESCRIPTION
http://php.net/manual/en/language.references.pass.php

PHP 5.3 doc says:
There is no reference sign on a function call - only on function definitions. Function definitions alone are enough to correctly pass the argument by reference. As of PHP 5.3.0, you will get a warning saying that "call-time pass-by-reference" is deprecated when you use & in foo(&$a);. 

PHP 5.4 throws a fatal error
