### PR TITLE
This solves a problem with doubly-encoded identity URLs

### DIFF
--- a/login.php
+++ b/login.php
@@ -33,7 +33,7 @@ function openid_authenticate($user) {
 
 	} else if ( array_key_exists('finish_openid', $_REQUEST) ) {
 
-		$identity_url= $_REQUEST['identity_url'];
+		$identity_url= urldecode($_REQUEST['identity_url']);
 
 		if ( !wp_verify_nonce($_REQUEST['_wpnonce'], 'openid_login_' . md5($identity_url)) ) {
 			$user = new WP_Error('openid_login_error', 'Error during OpenID authentication.  Please try again. (invalid nonce)');


### PR DESCRIPTION
I have not checked where exactly the problem is but I was getting an
URL-encoded identity_url when trying to log into a subdomain blog
(https://tips.at.gg3.net/) on a multisite wordpress installation. The
plugin worked just fine on the main blog (https://at.gg3.net/).
