### PR TITLE
Removed Cool URL for XRDS.

### DIFF
--- a/common.php
+++ b/common.php
@@ -613,11 +613,7 @@ function openid_service_url($service, $scheme = null) {
 	if (!defined('OPENID_SSL') || !OPENID_SSL) $scheme = null;
 	$url = site_url('/', $scheme);
 
-	if ($wp_rewrite->using_permalinks()) {
-		$url .= 'index.php/openid/' . $service;
-	} else {
-		$url .= '?openid=' . $service;
-	}
+    $url .= '?openid=' . $service;
 
 	return $url;
 }


### PR DESCRIPTION
Attempting to provide the Cool URL in this way can cause a 404 error. Since this is a reference only provided to and consumed by automatic services, hackability is less important.
