### PR TITLE
Make profile URL updates optional

### DIFF
--- a/admin_panels.php
+++ b/admin_panels.php
@@ -73,12 +73,14 @@ function openid_admin_panels() {
 function openid_admin_register_settings() {
 	register_setting('general', 'openid_required_for_registration');
 
+
 	register_setting('discussion', 'openid_no_require_name');
 	register_setting('discussion', 'openid_enable_approval');
 	register_setting('discussion', 'openid_enable_commentform');
 
 	register_setting('openid', 'openid_blog_owner');
 	register_setting('openid', 'openid_cap');
+	register_setting('openid', 'openid_secure_profile_urls');
 }
 
 
@@ -235,6 +237,21 @@ function openid_options_page() {
 					</td>
 				</tr>
 			<?php endif; //!empty($users) ?>
+				<tr>
+					<th scope="row"><?php _e('Security Settings', 'openid') ?></td>
+					<td>
+						<strong><?php _e('You can secure the OpenID plugin with the following options:', 'openid') ?></strong>
+						
+						<?php
+							$opt_secure_profile_urls = get_option('openid_secure_profile_urls');
+						?>
+						<p><label>
+							<input type="checkbox" name="openid_secure_profile_urls" value="true"<?php checked($opt_secure_profile_urls == 'true', true) ?> /> 
+							<?php _e('Require that users set their profile URL to one of their claimed OpenID URLs') ?>
+						</label></p>
+						
+					</td>
+				</tr>
 			</table>
 
 			<table class="form-table optiontable editform">
@@ -248,14 +265,12 @@ function openid_options_page() {
 					</td>
 				</tr>
 			</table>
-
 			<?php settings_fields('openid'); ?>
 			<p class="submit"><input type="submit" class="button-primary" name="info_update" value="<?php _e('Save Changes') ?>" /></p>
 		</form>
 	</div>
 		<?php
 }
-
 
 /**
  * Handle user management of OpenID associations.
@@ -593,6 +608,8 @@ function openid_printSystemStatus() {
 		($openid_enabled ? '' : 'There are problems above that must be dealt with before the plugin can be used.') );
 
 	if( $openid_enabled ) {	// Display status information
+		echo settings_fields('openid');
+		
 		echo'<p><strong>' . __('Status information:', 'openid') . '</strong> ' . __('All Systems Nominal', 'openid') 
 		. '<small> (<a href="#TB_inline?height=600&width=800&inlineId=openid_system_status" id="openid_status_link" class="thickbox" title="' . __('System Status', 'openid') . '">' . __('Toggle More/Less', 'openid') . '</a>)</small> </p>';
 	} else {

--- a/admin_panels.php
+++ b/admin_panels.php
@@ -823,6 +823,7 @@ function openid_finish_verify($identity_url, $action) {
  * hook in and call when user is updating their profile URL... make sure it is an OpenID they control.
  */
 function openid_personal_options_update() {
+	if (!get_option('openid_secure_profile_urls') === true) return;
 	$user = wp_get_current_user();
 
 	if (!openid_ensure_url_match($user, $_POST['url'])) {

--- a/common.php
+++ b/common.php
@@ -88,6 +88,7 @@ function openid_activate_plugin() {
 	add_option( 'openid_enable_approval', false );
 	add_option( 'openid_xrds_returnto', true );
 	add_option( 'openid_comment_displayname_length', 12 );
+	add_option( 'openid_secure_profile_urls', true );
 
 	openid_create_tables();
 	openid_migrate_old_data();
@@ -170,6 +171,7 @@ function openid_uninstall_plugin() {
 	delete_option('openid_blog_owner');
 	delete_option('openid_no_require_name');
 	delete_option('openid_required_for_registration');
+	delete_option('openid_secure_profile_urls');
 
 	// historical options
 	openid_remove_historical_options();


### PR DESCRIPTION
Add an option to the plugin to optionally require that a user's profile URL is updated when they add an OpenID to their profile and optionally require, when a user changes their profile URL, that it must be one of their claimed OpenIDs.