### PR TITLE
Display two new errors

### DIFF
--- a/common.php
+++ b/common.php
@@ -331,7 +331,11 @@ function openid_create_new_user($identity_url, &$user_data) {
 	$user_data['user_pass'] = substr( md5( uniqid( microtime() ) ), 0, 7);
 	$user_id = wp_insert_user( $user_data );
 
-	if( $user_id ) { // created ok
+	if ($user_id instanceof WP_Error) {
+	    openid_message($user_id->get_error_message());
+	    openid_status('error');
+	    return;
+	} else if ( is_integer($user_id) ) { // created ok
 
 		$user_data['ID'] = $user_id;
 		// XXX this all looks redundant, see openid_set_current_user

--- a/login.php
+++ b/login.php
@@ -68,14 +68,25 @@ function openid_finish_login($identity_url, $action) {
 		
 	// create new user account if appropriate
 	$user_id = get_user_by_openid($identity_url);
-	if ( $identity_url && !$user_id && get_option('users_can_register') ) {
-		$user_data =& openid_get_user_data($identity_url);
-		openid_create_new_user($identity_url, $user_data);
+	if ($identity_url && !$user_id) {
+	    if (get_option('users_can_register')) {
+	        // registration is enabled so create a new user
+    		$user_data =& openid_get_user_data($identity_url);
+    		openid_create_new_user($identity_url, $user_data);
+	    } else {
+	        // generate a error because it is not possible to create a new user
+	        openid_message(__('Unable to create a new user.', 'openid'));
+	        openid_status('error');
+	    }
 	}
 	
 	// return to wp-login page
 	$url = get_option('siteurl') . '/wp-login.php';
-	if (empty($identity_url)) {
+	
+	$status = openid_status();
+	$error = openid_message();
+	
+	if ($status == 'error' && !empty($error)) {
 		$url = add_query_arg('openid_error', openid_message(), $url);
 	}
 


### PR DESCRIPTION
Display error when an user tries to register a new openid with an e-mail that is already in the Wordpress database and when an user try to login with a new openid identity and registration is disabled
