### PR TITLE
Two minor fixes to Wordpress functions calls

### DIFF
--- a/common.php
+++ b/common.php
@@ -346,7 +346,7 @@ function openid_create_new_user($identity_url, &$user_data) {
 		}
 
 		// notify of user creation
-		wp_new_user_notification( $user->user_login );
+		wp_new_user_notification( $user_id );
 
 		wp_clearcookie();
 		wp_setcookie( $user->user_login, md5($user->user_pass), true, '', '', true );

--- a/server_ext.php
+++ b/server_ext.php
@@ -167,7 +167,8 @@ function openid_server_sreg_from_profile($field) {
 			break;
 
 		case 'fullname':
-			$value = get_user_meta($user->ID, 'display_name', true);
+			$user_data = get_userdata($user->ID);
+			$value = $user_data->display_name;
 			break;
 	}
 


### PR DESCRIPTION
Functions wp_new_user_notification() expects user id and not user name and get display_name using get_userdata() since it is not available as a user meta.
