### PR TITLE
Make the last argument optional

### DIFF
--- a/common.php
+++ b/common.php
@@ -195,7 +195,7 @@ function openid_cleanup() {
 /*
  * Customer error handler for calls into the JanRain library
  */
-function openid_customer_error_handler( $errno, $errmsg, $filename, $linenum, $vars ) {
+function openid_customer_error_handler( $errno, $errmsg, $filename, $linenum, $vars = NULL) {
 	if ( 2048 == ( 2048 & $errno ) ) {
 		return;
 	}

--- a/common.php
+++ b/common.php
@@ -195,7 +195,7 @@ function openid_cleanup() {
 /*
  * Customer error handler for calls into the JanRain library
  */
-function openid_customer_error_handler( $errno, $errmsg, $filename, $linenum, $vars = NULL) {
+function openid_customer_error_handler( $errno, $errmsg, $filename, $linenum, $vars = null ) {
 	if ( 2048 == ( 2048 & $errno ) ) {
 		return;
 	}


### PR DESCRIPTION
This is deprecated in php 7.2, and removed in php 8.0.
Fix #55